### PR TITLE
Resolver problemas legislatura

### DIFF
--- a/backend/api/senado/router.py
+++ b/backend/api/senado/router.py
@@ -1074,9 +1074,16 @@ def get_votacao_materia(legislatura: int, codigo_materia: int):
                 JOIN senado.parlamentar p ON vp.codigo_parlamentar = p.codigo
                 WHERE vp.codigo_materia = %s
                   AND vp.sigla_descricao_voto NOT IN ('P-NRV', 'AP', 'Presidente (art. 51 RISF)', 'LS', 'NCom')
-                ORDER BY m.ano DESC, m.sigla, m.numero, p.nome_parlamentar
             """
-            cursor.execute(query, (codigo_materia,))
+            params = [codigo_materia]
+            if legislatura:
+                start_year = 2023 - (57 - legislatura) * 4
+                end_year = start_year + 3
+                query += " AND m.ano BETWEEN %s AND %s"
+                params.extend([start_year, end_year])
+
+            query += " ORDER BY m.ano DESC, m.sigla, m.numero, p.nome_parlamentar"
+            cursor.execute(query, tuple(params))
             resultados = cursor.fetchall()
             return {
                 "votacao": [
@@ -1119,7 +1126,14 @@ def get_emendas_lista_senador(legislatura: int, senador_codigo: int, pagina: int
                        OR lower(e.nome_autor) = lower(s.nome_parlamentar))
                 WHERE s.codigo = %s
             """
-            cursor.execute(query_count, (senador_codigo,))
+            params_count = [senador_codigo]
+            if legislatura:
+                start_year = 2023 - (57 - legislatura) * 4
+                end_year = start_year + 3
+                query_count += " AND e.ano BETWEEN %s AND %s"
+                params_count.extend([start_year, end_year])
+
+            cursor.execute(query_count, tuple(params_count))
             total_items = cursor.fetchone()[0]
             total_paginas = (total_items + itens_per_page - 1) // itens_per_page
 
@@ -1137,10 +1151,17 @@ def get_emendas_lista_senador(legislatura: int, senador_codigo: int, pagina: int
                   ON (lower(e.nome_autor) = lower(s.nome_completo) 
                       OR lower(e.nome_autor) = lower(s.nome_parlamentar))
                 WHERE s.codigo = %s
-                ORDER BY e.ano DESC, e.valor_pago DESC
-                LIMIT %s OFFSET %s
             """
-            cursor.execute(query, (senador_codigo, itens_per_page, offset))
+            params = [senador_codigo]
+            if legislatura:
+                start_year = 2023 - (57 - legislatura) * 4
+                end_year = start_year + 3
+                query += " AND e.ano BETWEEN %s AND %s"
+                params.extend([start_year, end_year])
+
+            query += " ORDER BY e.ano DESC, e.valor_pago DESC LIMIT %s OFFSET %s"
+            params.extend([itens_per_page, offset])
+            cursor.execute(query, tuple(params))
             res = cursor.fetchall()
             
             return {

--- a/backend/api/senado/router.py
+++ b/backend/api/senado/router.py
@@ -933,7 +933,7 @@ def get_resumo_emendas(legislatura: int):
                 cursor.execute(query_totais)
             
             totais_row = cursor.fetchone()
-            valor_total_global_totais = float(totais_row[3]) if totais_row[3] else 1.0
+            valor_total_global = float(totais_row[3]) if totais_row[3] and float(totais_row[3]) > 0 else 1.0
             
             # 2. Distribuição por Área (Optimized with CTE)
             if legislatura:
@@ -969,7 +969,6 @@ def get_resumo_emendas(legislatura: int):
                 cursor.execute(query_areas)
             
             areas_raw = cursor.fetchall()
-            valor_total_global = sum(float(r[1]) for r in areas_raw) if areas_raw else 1.0
 
             areas_formatadas = [
                 {

--- a/frontend/src/views/camara/DespesasView.vue
+++ b/frontend/src/views/camara/DespesasView.vue
@@ -210,7 +210,7 @@
 
 <script setup lang="ts">
 import { Banknote, Users, Building2, ChevronRight } from 'lucide-vue-next'
-import { onMounted, computed, ref } from 'vue'
+import { onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseCard from '@/components/ui/BaseCard.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'

--- a/frontend/src/views/senado/DespesasView.vue
+++ b/frontend/src/views/senado/DespesasView.vue
@@ -213,7 +213,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted} from 'vue'
+import { computed, onMounted} from 'vue'
 import { useRouter } from 'vue-router'
 import { Banknote, Users, Receipt, ChevronRight } from 'lucide-vue-next'
 import BaseCard from '@/components/ui/BaseCard.vue'


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the Senado API endpoints, mainly focusing on filtering by legislatura (legislative session) and ensuring accurate value calculations. Additionally, there are minor frontend code cleanups. The most important changes are as follows:

### Backend: Filtering and Query Improvements

* Added filtering by `legislatura` (session) to the `get_votacao_materia` and `get_emendas_lista_senador` endpoints, by dynamically computing the year range and updating SQL queries and parameters accordingly. This ensures that results are scoped to the correct legislative period. [[1]](diffhunk://#diff-148fc87978abbaebd9c38a6cf1290c983bf985ab258f241153eb890eca767be9L1077-R1085) [[2]](diffhunk://#diff-148fc87978abbaebd9c38a6cf1290c983bf985ab258f241153eb890eca767be9L1122-R1135) [[3]](diffhunk://#diff-148fc87978abbaebd9c38a6cf1290c983bf985ab258f241153eb890eca767be9L1140-R1163)
* Fixed the calculation of `valor_total_global` in `get_resumo_emendas` to prevent division by zero and ensure the value is always positive and non-zero.
* Removed redundant recalculation of `valor_total_global` from the sum of areas, relying instead on the value from the totals query.

### Frontend: Code Cleanup

* Removed unused `ref` imports from `DespesasView.vue` files in both the Câmara and Senado folders, simplifying the code. [[1]](diffhunk://#diff-ab071dcabdb37c1e3ed14ab917790520baffbd4022e7f177f9c967bb8cf82110L213-R213) [[2]](diffhunk://#diff-abc91651f70f9e4fcee0f95d45d8b70856047cb48c606de9b4b84dfd871dd7a3L216-R216)