### PR TITLE
Verificando erro

### DIFF
--- a/README_API.md
+++ b/README_API.md
@@ -99,7 +99,8 @@ http://localhost:8000/api/senado/{senador_codigo}/despesas
 - **`GET /empresas/estatisticas`**: Ranking das empresas fornecedoras do Senado.
     - **Params**: `legislatura` (int, opcional).
 - **`GET /materia/listar`**: Consulta de matérias legislativas (projetos).
-    - **Params**: `siglaTipo`, `ano`, `ementa`, `senador` (nome), `legislatura`, `pagina`.
+    - **Params**: `siglaTipo`, `ano`, `ementa`, `senador` (nome), `legislatura`, `pagina`, `limite`.
+    - **Resposta**: retorna `materia`, `paginacao` e `estatisticas` (total, tipo mais frequente e distribuição por tipo).
 
 ### Emendas Parlamentares
 - **`GET /emendas`**: Lista de emendas do Senado.

--- a/README_API.md
+++ b/README_API.md
@@ -53,6 +53,7 @@ http://localhost:8000/api/senado/{senador_codigo}/despesas
 - **`GET /lista`**: Lista todos os deputados ativos.
     - **Params**: `legislatura` (int, opcional) - Filtra quem exerceu mandato naquela legislatura.
 - **`GET /estatisticas`**: Estatísticas gerais (total de deputados, distribuição por região).
+    - **Resposta**: inclui `total_deputados`, `total_regioes`, `total_ufs` e `deputados_por_regiao`.
     - **Params**: `legislatura` (int, opcional).
 - **`GET /{deputado_id}`**: Perfil detalhado de um deputado.
     - **Params**: `legislatura` (int, opcional) - Se passado, mostra as estatísticas focadas naquele período.
@@ -72,6 +73,7 @@ http://localhost:8000/api/senado/{senador_codigo}/despesas
 ### Projetos Legislativos
 - **`GET /proposicoes`**: Lista de projetos de lei e outras proposições.
     - **Params**: `siglaTipo`, `ano`, `ementa`, `deputado` (nome), `legislatura`, `pagina`.
+    - **Resposta**: retorna `proposicoes`, `paginacao` e `estatisticas` (total, tipo mais frequente e distribuição por tipo no conjunto filtrado completo).
 - **`GET /proposicoes/{id}/votos`**: Histórico de votação nominal de um projeto específico.
 
 ---

--- a/backend/api/camara/router.py
+++ b/backend/api/camara/router.py
@@ -323,8 +323,8 @@ def get_lista_proposicoes(
     ano: int = Query(None), 
     ementa: str = Query(None), 
     deputado: str = Query(None),
-    limite: int = Query(15),
-    pagina: int = 1
+    limite: int = Query(15, ge=1, le=200),
+    pagina: int = Query(1, ge=1)
 ):
     offset = (pagina - 1) * limite
     conn = None
@@ -334,87 +334,82 @@ def get_lista_proposicoes(
             raise HTTPException(status_code=503, detail="Banco de dados indisponível")
         
         with conn.cursor() as cursor:
-            # 1. Total para paginação
-            query_count = """
-                SELECT COUNT(DISTINCT p.id)
+            from_clause = """
                 FROM camara.proposicoes p
             """
             if deputado:
-                query_count += """
+                from_clause += """
                     INNER JOIN camara.votacoes_proposicoes vp ON p.id = vp.proposicao_id
                     INNER JOIN camara.votacoes_votos vv ON vp.votacao_id = vv.votacao_id
                     INNER JOIN camara.deputados d ON vv.deputado_id = d.id
                 """
-            query_count += " WHERE 1=1"
-            params_count = []
+
+            filtros = ["1=1"]
+            params = []
+
             if siglaTipo:
-                query_count += " AND p.sigla_tipo = %s"
-                params_count.append(siglaTipo)
+                filtros.append("p.sigla_tipo = %s")
+                params.append(siglaTipo)
             if ano:
-                query_count += " AND p.ano = %s"
-                params_count.append(ano)
-            if ementa:
-                query_count += " AND p.ementa ILIKE %s"
-                params_count.append(f"%{ementa}%")
-            if deputado:
-                query_count += " AND d.nome_civil ILIKE %s"
-                params_count.append(f"%{deputado}%")
+                filtros.append("p.ano = %s")
+                params.append(ano)
             if legislatura:
                 start_year = 2023 - (57 - legislatura) * 4
                 end_year = start_year + 3
-                query_count += " AND p.ano BETWEEN %s AND %s"
-                params_count.extend([start_year, end_year])
-            
-            cursor.execute(query_count, tuple(params_count))
+                filtros.append("p.ano BETWEEN %s AND %s")
+                params.extend([start_year, end_year])
+            if ementa:
+                filtros.append("p.ementa ILIKE %s")
+                params.append(f"%{ementa}%")
+            if deputado:
+                filtros.append("d.nome_civil ILIKE %s")
+                params.append(f"%{deputado}%")
+
+            where_clause = " WHERE " + " AND ".join(filtros)
+
+            # 1. Total para paginação
+            query_count = f"""
+                SELECT COUNT(DISTINCT p.id)
+                {from_clause}
+                {where_clause}
+            """
+            cursor.execute(query_count, tuple(params))
             total_items = cursor.fetchone()[0]
             total_paginas = (total_items + limite - 1) // limite
 
-            # 2. Dados paginados
-            query = """
-                SELECT DISTINCT ON (p.id)
-                    p.id, 
-                    p.sigla_tipo as "siglaTipo", 
-                    p.numero, 
-                    p.ano, 
-                    p.ementa, 
-                    p.data_apresentacao as "dataApresentacao"
-                FROM camara.proposicoes p
+            # 2. Distribuição por tipo (sobre todo o conjunto filtrado)
+            query_tipos = f"""
+                SELECT COALESCE(p.sigla_tipo, 'N/D') as sigla_tipo, COUNT(DISTINCT p.id) as quantidade
+                {from_clause}
+                {where_clause}
+                GROUP BY COALESCE(p.sigla_tipo, 'N/D')
+                ORDER BY quantidade DESC, sigla_tipo ASC
             """
-            params = []
-            
-            if deputado:
-                query += """
-                    INNER JOIN camara.votacoes_proposicoes vp ON p.id = vp.proposicao_id
-                    INNER JOIN camara.votacoes_votos vv ON vp.votacao_id = vv.votacao_id
-                    INNER JOIN camara.deputados d ON vv.deputado_id = d.id
-                """
-            
-            query += " WHERE 1=1"
-            
-            if siglaTipo:
-                query += " AND p.sigla_tipo = %s"
-                params.append(siglaTipo)
-            if ano:
-                query += " AND p.ano = %s"
-                params.append(ano)
-            if ementa:
-                query += " AND p.ementa ILIKE %s"
-                params.append(f"%{ementa}%")
-            if deputado:
-                query += " AND d.nome_civil ILIKE %s"
-                params.append(f"%{deputado}%")
-            if legislatura:
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                query += " AND p.ano BETWEEN %s AND %s"
-                params.extend([start_year, end_year])
-                
-            query += " ORDER BY p.id DESC LIMIT %s OFFSET %s"
-            params.extend([limite, offset])
+            cursor.execute(query_tipos, tuple(params))
+            tipos_raw = cursor.fetchall()
+            distribuicao_tipos = [
+                {"tipo": r[0], "quantidade": int(r[1])}
+                for r in tipos_raw
+            ]
 
-            cursor.execute(query, tuple(params))
+            # 3. Dados paginados
+            query_data = f"""
+                SELECT DISTINCT ON (p.id)
+                    p.id,
+                    p.sigla_tipo as "siglaTipo",
+                    p.numero,
+                    p.ano,
+                    p.ementa,
+                    p.data_apresentacao as "dataApresentacao"
+                {from_clause}
+                {where_clause}
+                ORDER BY p.id DESC
+                LIMIT %s OFFSET %s
+            """
+            params_data = [*params, limite, offset]
+            cursor.execute(query_data, tuple(params_data))
             res = cursor.fetchall()
-            
+
             return {
                 "proposicoes": [
                     {
@@ -433,6 +428,12 @@ def get_lista_proposicoes(
                     "pagina": pagina,
                     "total_paginas": total_paginas,
                     "itens_por_pagina": limite
+                },
+                "estatisticas": {
+                    "total": total_items,
+                    "tipos_diferentes": len(distribuicao_tipos),
+                    "tipo_mais_frequente": distribuicao_tipos[0]["tipo"] if distribuicao_tipos else None,
+                    "distribuicao_tipos": distribuicao_tipos
                 }
             }
     except Exception as e:
@@ -594,8 +595,24 @@ def get_estatisticas_gerais(legislatura: int):
             cursor.execute(query_regiao, (legislatura,) if legislatura else ())
             deputados_regiao = [{"name": r[0], "value": int(r[1])} for r in cursor.fetchall()]
 
+            # 3. Total de UFs com deputados na seleção
+            query_ufs = """
+                SELECT COUNT(DISTINCT m.sigla_uf)
+                FROM camara.deputados_mandatos m
+                WHERE m.sigla_uf IS NOT NULL
+            """
+            params_ufs = []
+            if legislatura:
+                query_ufs += " AND m.legislatura_id = %s"
+                params_ufs.append(legislatura)
+
+            cursor.execute(query_ufs, tuple(params_ufs))
+            total_ufs = cursor.fetchone()[0] or 0
+
             return {
                 "total_deputados": int(total_deputados),
+                "total_regioes": len(deputados_regiao),
+                "total_ufs": int(total_ufs),
                 "deputados_por_regiao": deputados_regiao
             }
     except Exception as e:
@@ -690,15 +707,20 @@ def get_comparativo_deputados(legislatura: int, id1: int, id2: int, ano: int = N
                             "valor": valor
                         }
 
-            # 3. Buscar Últimas Despesas (Top 10)
+            # 3. Buscar Últimas Despesas (histórico completo, mais recentes primeiro)
             for dep_id in [id1, id2]:
                 cursor.execute("""
                     SELECT d.ano, d.mes, d.tipo_despesa, d.valor_documento as valor, d.url_documento
                     FROM camara.deputados_despesas d
                     JOIN camara.deputados_mandatos m ON d.mandato_id = m.id
                     WHERE m.deputado_id = %s
-                    ORDER BY d.ano DESC, d.mes DESC
-                    LIMIT 10
+                    ORDER BY
+                        COALESCE(
+                            d.data_documento,
+                            TO_DATE(d.ano::text || '-' || LPAD(d.mes::text, 2, '0') || '-01', 'YYYY-MM-DD')
+                        ) DESC,
+                        d.id DESC
+                    LIMIT 12
                 """, (dep_id,))
                 recentes = cursor.fetchall()
                 

--- a/backend/api/senado/router.py
+++ b/backend/api/senado/router.py
@@ -12,6 +12,10 @@ router = APIRouter(
     tags=["Senado"]
 )
 
+def _periodo_legislatura(legislatura: int):
+    inicio = 2023 - (57 - legislatura) * 4
+    return inicio, inicio + 3
+
 @router.get("/legislaturas", summary="Lista todas as legislaturas disponíveis na base")
 @lru_cache(maxsize=1)
 def get_legislaturas_senado():
@@ -360,22 +364,31 @@ WHERE codigo = %s;"""
                 FROM portal.emendas e
                 JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
                 WHERE s.id = %s
-                  AND EXISTS (
-                      SELECT 1 FROM senado.mandato m 
-                      WHERE m.codigo_parlamentar = s.id 
-                      AND (
-                          CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 + 3
-                          OR
-                          CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 + 3
-                      )
-                  )
             """
             params_emendas = [senador_codigo]
             if legislatura:
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                query_emendas += " AND CAST(e.ano AS INTEGER) BETWEEN %s AND %s"
-                params_emendas.extend([start_year, end_year])
+                start_year, end_year = _periodo_legislatura(legislatura)
+                query_emendas += """
+                    AND CAST(e.ano AS INTEGER) BETWEEN %s AND %s
+                    AND EXISTS (
+                        SELECT 1 FROM senado.mandato m
+                        WHERE m.codigo_parlamentar = s.id
+                          AND (m.primeira_legislatura = %s OR m.segunda_legislatura = %s)
+                    )
+                """
+                params_emendas.extend([start_year, end_year, str(legislatura), str(legislatura)])
+            else:
+                query_emendas += """
+                    AND EXISTS (
+                        SELECT 1 FROM senado.mandato m
+                        WHERE m.codigo_parlamentar = s.id
+                          AND (
+                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 + 3
+                              OR
+                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 + 3
+                          )
+                    )
+                """
 
             cursor.execute(query_emendas, tuple(params_emendas))
             emendas_res_row = cursor.fetchone()
@@ -594,13 +607,13 @@ def get_despesas_estatisticas(legislatura: int):
             query_cat = f"""
                 WITH ranking_categorias AS (
                     SELECT 
-                        d.tipo_despesa, 
+                        COALESCE(NULLIF(TRIM(d.tipo_despesa), ''), 'Não informado') AS tipo_despesa,
                         SUM(d.valor_reembolsado) AS valor,
                         ROW_NUMBER() OVER (ORDER BY SUM(d.valor_reembolsado) DESC) as rank
                     FROM senado.despesa_ceaps d
                     {join_mandato}
                     WHERE 1=1 {where_leg}
-                    GROUP BY d.tipo_despesa
+                    GROUP BY COALESCE(NULLIF(TRIM(d.tipo_despesa), ''), 'Não informado')
                 )
                 SELECT 
                     CASE WHEN rank <= 9 THEN tipo_despesa ELSE 'Outros' END AS categoria,
@@ -709,10 +722,10 @@ def get_materia_listar(
     ano: int = Query(None),
     ementa: str = Query(None),
     senador: str = Query(None),
-    pagina: int = 1
+    limite: int = Query(15, ge=1, le=200),
+    pagina: int = Query(1, ge=1)
 ):
-    itens_por_pagina = 15
-    offset = (pagina - 1) * itens_por_pagina
+    offset = (pagina - 1) * limite
     conn = None
     try:
         conn = db.get_db_connection()
@@ -720,52 +733,90 @@ def get_materia_listar(
             raise HTTPException(status_code=503, detail="Banco de dados indisponível")
         
         with conn.cursor() as cursor:
-            query = """
-                SELECT DISTINCT
-                    m.codigo AS id,
-                    m.sigla,
-                    m.numero,
-                    m.ano,
-                    m.ementa,
-                    m.data,
-                    autor.nome_parlamentar AS autor_principal
+            from_clause = """
                 FROM senado.materia m
+            """
+            if senador:
+                from_clause += """
+                    INNER JOIN senado.votacao_parlamentar vp ON m.codigo = vp.codigo_materia
+                    INNER JOIN senado.parlamentar sv ON vp.codigo_parlamentar = sv.codigo
+                """
+
+            filtros = ["1=1"]
+            params = []
+
+            if siglaTipo:
+                filtros.append("m.sigla = %s")
+                params.append(siglaTipo)
+            if ano:
+                filtros.append("m.ano = %s")
+                params.append(ano)
+            if legislatura:
+                start_year, end_year = _periodo_legislatura(legislatura)
+                filtros.append("m.ano BETWEEN %s AND %s")
+                params.extend([start_year, end_year])
+            if ementa:
+                filtros.append("m.ementa ILIKE %s")
+                params.append(f"%{ementa}%")
+            if senador:
+                filtros.append("(sv.nome_parlamentar ILIKE %s OR sv.nome_completo ILIKE %s)")
+                params.extend([f"%{senador}%", f"%{senador}%"])
+
+            where_clause = " WHERE " + " AND ".join(filtros)
+
+            # 1. Total para paginação
+            query_count = f"""
+                SELECT COUNT(DISTINCT m.codigo)
+                {from_clause}
+                {where_clause}
+            """
+            cursor.execute(query_count, tuple(params))
+            total_items = cursor.fetchone()[0]
+            total_paginas = (total_items + limite - 1) // limite
+
+            # 2. Distribuição por tipo (sobre todo o conjunto filtrado)
+            query_tipos = f"""
+                SELECT m.sigla, COUNT(DISTINCT m.codigo) as quantidade
+                {from_clause}
+                {where_clause}
+                GROUP BY m.sigla
+                ORDER BY quantidade DESC, m.sigla ASC
+            """
+            cursor.execute(query_tipos, tuple(params))
+            tipos_raw = cursor.fetchall()
+            distribuicao_tipos = [
+                {"tipo": r[0], "quantidade": int(r[1])}
+                for r in tipos_raw
+            ]
+
+            # 3. Página de dados
+            from_clause_data = from_clause + """
                 LEFT JOIN senado.autoria a ON a.codigo_materia = m.codigo AND a.autor_principal = true
                 LEFT JOIN senado.parlamentar autor ON a.codigo_parlamentar = autor.codigo
             """
-            params = []
-
-            if senador:
-                query += """
-                    INNER JOIN senado.votacao_parlamentar vp ON m.codigo = vp.codigo_materia
-                    INNER JOIN senado.parlamentar p ON vp.codigo_parlamentar = p.codigo
-                """
-
-            query += " WHERE 1=1"
-
-            if siglaTipo:
-                query += " AND m.sigla = %s"
-                params.append(siglaTipo)
-            if ano:
-                query += " AND m.ano = %s"
-                params.append(ano)
-            if legislatura:
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                query += " AND m.ano BETWEEN %s AND %s"
-                params.extend([start_year, end_year])
-            if ementa:
-                query += " AND m.ementa ILIKE %s"
-                params.append(f"%{ementa}%")
-            if senador:
-                query += " AND p.nome_parlamentar ILIKE %s"
-                params.append(f"%{senador}%")
-
-            query += " ORDER BY m.ano DESC, m.sigla, m.numero LIMIT %s OFFSET %s"
-            params.extend([itens_por_pagina, offset])
-
-            cursor.execute(query, tuple(params))
+            query = f"""
+                WITH materia_filtrada AS (
+                    SELECT DISTINCT ON (m.codigo)
+                        m.codigo AS id,
+                        m.sigla,
+                        m.numero,
+                        m.ano,
+                        m.ementa,
+                        m.data,
+                        autor.nome_parlamentar AS autor_principal
+                    {from_clause_data}
+                    {where_clause}
+                    ORDER BY m.codigo, m.data DESC NULLS LAST, m.ano DESC
+                )
+                SELECT id, sigla, numero, ano, ementa, data, autor_principal
+                FROM materia_filtrada
+                ORDER BY ano DESC, sigla, numero
+                LIMIT %s OFFSET %s
+            """
+            params_data = [*params, limite, offset]
+            cursor.execute(query, tuple(params_data))
             resultados = cursor.fetchall()
+
             return {
                 "materia": [
                     {
@@ -778,7 +829,19 @@ def get_materia_listar(
                         "autor_principal": r[6]
                     }
                     for r in resultados
-                ]
+                ],
+                "paginacao": {
+                    "total": total_items,
+                    "pagina": pagina,
+                    "total_paginas": total_paginas,
+                    "itens_por_pagina": limite
+                },
+                "estatisticas": {
+                    "total": total_items,
+                    "tipos_diferentes": len(distribuicao_tipos),
+                    "tipo_mais_frequente": distribuicao_tipos[0]["tipo"] if distribuicao_tipos else None,
+                    "distribuicao_tipos": distribuicao_tipos
+                }
             }
     except Exception as e:
         logging.error(f"Erro ao buscar matéria: {e}")
@@ -804,8 +867,50 @@ def get_lista_emendas(
             raise HTTPException(status_code=503, detail="Banco de dados indisponível")
         
         with conn.cursor() as cursor:
+            filtros_base = []
+            params_base = []
+
+            if legislatura:
+                start_year, end_year = _periodo_legislatura(legislatura)
+                filtros_base.append("CAST(e.ano AS INTEGER) BETWEEN %s AND %s")
+                params_base.extend([start_year, end_year])
+                filtros_base.append("""
+                    EXISTS (
+                        SELECT 1
+                        FROM senado.mandato m
+                        WHERE m.codigo_parlamentar = p.codigo
+                          AND (m.primeira_legislatura = %s OR m.segunda_legislatura = %s)
+                    )
+                """)
+                params_base.extend([str(legislatura), str(legislatura)])
+            else:
+                filtros_base.append("""
+                    EXISTS (
+                        SELECT 1
+                        FROM senado.mandato m
+                        WHERE m.codigo_parlamentar = p.codigo
+                          AND (
+                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4
+                                                         AND 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 + 3
+                              OR
+                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4
+                                                         AND 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 + 3
+                          )
+                    )
+                """)
+
+            if nome_senador:
+                filtros_base.append("(p.nome_completo ILIKE %s OR p.nome_parlamentar ILIKE %s)")
+                params_base.extend([f"%{nome_senador}%", f"%{nome_senador}%"])
+
+            if ano:
+                filtros_base.append("CAST(e.ano AS INTEGER) = %s")
+                params_base.append(ano)
+
+            where_clause = " AND ".join(filtros_base)
+
             # 1. Total para paginação
-            query_count = """
+            query_count = f"""
                 WITH senadores_nomes AS (
                     SELECT codigo as id, lower(nome_completo) as nome FROM senado.parlamentar
                     UNION
@@ -814,48 +919,23 @@ def get_lista_emendas(
                 SELECT COUNT(*)
                 FROM portal.emendas e
                 JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
+                JOIN senado.parlamentar p ON p.codigo = s.id
+                WHERE {where_clause}
             """
-            
-            # Adicionar filtro de legislatura se especificado
-            where_conditions = []
-            params_count = []
-            
-            if legislatura:
-                query_count += """
-                    JOIN senado.mandato m ON s.id = m.codigo_parlamentar
-                """
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                where_conditions.append("(m.primeira_legislatura = %s OR m.segunda_legislatura = %s) AND CAST(e.ano AS INTEGER) BETWEEN %s AND %s")
-                params_count.extend([str(legislatura), str(legislatura), start_year, end_year])
-            
-            if nome_senador:
-                where_conditions.append("""s.id IN (
-                    SELECT codigo FROM senado.parlamentar 
-                    WHERE nome_completo ILIKE %s OR nome_parlamentar ILIKE %s
-                )""")
-                params_count.extend([f"%{nome_senador}%", f"%{nome_senador}%"])
-            
-            if ano:
-                where_conditions.append("e.ano = %s")
-                params_count.append(ano)
-            
-            if where_conditions:
-                query_count += " WHERE " + " AND ".join(where_conditions)
-            
-            cursor.execute(query_count, tuple(params_count))
+
+            cursor.execute(query_count, tuple(params_base))
             total_items = cursor.fetchone()[0]
             total_paginas = (total_items + itens_por_pagina - 1) // itens_por_pagina
 
             # 2. Dados paginados
-            query = """
+            query = f"""
                 WITH senadores_nomes AS (
-                    SELECT codigo as id, lower(nome_parlamentar) as nome, nome_parlamentar as nome_senador FROM senado.parlamentar
+                    SELECT codigo as id, lower(nome_completo) as nome FROM senado.parlamentar
                     UNION
-                    SELECT codigo as id, lower(nome_completo) as nome, nome_parlamentar as nome_senador FROM senado.parlamentar
+                    SELECT codigo as id, lower(nome_parlamentar) as nome FROM senado.parlamentar
                 )
                 SELECT 
-                    s.nome_senador as senador,
+                    p.nome_parlamentar as senador,
                     e.codigo_emenda as codigo,
                     e.ano,
                     e.tipo_emenda as tipo,
@@ -864,34 +944,12 @@ def get_lista_emendas(
                     e.localidade_gasto as localidade
                 FROM portal.emendas e
                 JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
+                JOIN senado.parlamentar p ON p.codigo = s.id
+                WHERE {where_clause}
+                ORDER BY CAST(e.ano AS INTEGER) DESC, e.valor_pago DESC
+                LIMIT %s OFFSET %s
             """
-            
-            # Adicionar JOIN e filtros
-            where_conditions_data = []
-            params = []
-            
-            if legislatura:
-                query += """
-                    JOIN senado.mandato m ON s.id = m.codigo_parlamentar
-                """
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                where_conditions_data.append("(m.primeira_legislatura = %s OR m.segunda_legislatura = %s) AND CAST(e.ano AS INTEGER) BETWEEN %s AND %s")
-                params.extend([str(legislatura), str(legislatura), start_year, end_year])
-            
-            if nome_senador:
-                where_conditions_data.append("s.nome_senador ILIKE %s")
-                params.append(f"%{nome_senador}%")
-            
-            if ano:
-                where_conditions_data.append("e.ano = %s")
-                params.append(ano)
-            
-            if where_conditions_data:
-                query += " WHERE " + " AND ".join(where_conditions_data)
-                
-            query += " ORDER BY e.ano DESC, e.valor_pago DESC LIMIT %s OFFSET %s"
-            params.extend([itens_por_pagina, offset])
+            params = [*params_base, itens_por_pagina, offset]
 
             cursor.execute(query, tuple(params))
             res = cursor.fetchall()
@@ -934,149 +992,102 @@ def get_resumo_emendas(legislatura: int):
             raise HTTPException(status_code=503, detail="Banco de dados indisponível")
         
         with conn.cursor() as cursor:
-            # 1. Totais Gerais (Optimized with CTE)
+            params_base = []
             if legislatura:
-                query_totais = """
-                    WITH senadores_nomes AS (
-                        SELECT codigo as id, lower(nome_completo) as nome FROM senado.parlamentar
-                        UNION
-                        SELECT codigo as id, lower(nome_parlamentar) as nome FROM senado.parlamentar
+                start_year, end_year = _periodo_legislatura(legislatura)
+                where_base = """
+                    CAST(e.ano AS INTEGER) BETWEEN %s AND %s
+                    AND EXISTS (
+                        SELECT 1
+                        FROM senado.mandato m
+                        WHERE m.codigo_parlamentar = p.codigo
+                          AND (m.primeira_legislatura = %s OR m.segunda_legislatura = %s)
                     )
-                    SELECT 
-                        COUNT(DISTINCT s.id) as total_senadores,
-                        COUNT(DISTINCT e.localidade_gasto) as total_municipios,
-                        COUNT(DISTINCT e.funcao) as total_areas,
-                        COALESCE(SUM(e.valor_pago), 0) as valor_total
-                    FROM portal.emendas e
-                    JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
-                    WHERE CAST(e.ano AS INTEGER) BETWEEN %s AND %s
                 """
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                cursor.execute(query_totais, (start_year, end_year))
+                params_base.extend([start_year, end_year, str(legislatura), str(legislatura)])
             else:
-                query_totais = """
-                    WITH senadores_nomes AS (
-                        SELECT codigo as id, lower(nome_completo) as nome FROM senado.parlamentar
-                        UNION
-                        SELECT codigo as id, lower(nome_parlamentar) as nome FROM senado.parlamentar
+                where_base = """
+                    EXISTS (
+                        SELECT 1
+                        FROM senado.mandato m
+                        WHERE m.codigo_parlamentar = p.codigo
+                          AND (
+                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4
+                                                         AND 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 + 3
+                              OR
+                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4
+                                                         AND 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 + 3
+                          )
                     )
-                    SELECT 
-                        COUNT(DISTINCT s.id) as total_senadores,
-                        COUNT(DISTINCT e.localidade_gasto) as total_municipios,
-                        COUNT(DISTINCT e.funcao) as total_areas,
-                        COALESCE(SUM(e.valor_pago), 0) as valor_total
-                    FROM portal.emendas e
-                    JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
                 """
-                cursor.execute(query_totais)
-            
-            totais_row = cursor.fetchone()
-            valor_total_global = float(totais_row[3]) if totais_row[3] and float(totais_row[3]) > 0 else 1.0
-            
-            # 2. Distribuição por Área (Optimized with CTE)
-            if legislatura:
-                query_areas = """
-                    WITH senadores_nomes AS (
-                        SELECT codigo as id, lower(nome_completo) as nome FROM senado.parlamentar
-                        UNION
-                        SELECT codigo as id, lower(nome_parlamentar) as nome FROM senado.parlamentar
-                    )
-                    SELECT e.funcao, SUM(e.valor_pago) as valor_total
-                    FROM portal.emendas e
-                    JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
-                    WHERE CAST(e.ano AS INTEGER) BETWEEN %s AND %s
-                    GROUP BY e.funcao
-                    ORDER BY valor_total DESC
-                """
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                cursor.execute(query_areas, (start_year, end_year))
-            else:
-                query_areas = """
-                    WITH senadores_nomes AS (
-                        SELECT lower(nome_completo) as nome FROM senado.parlamentar
-                        UNION
-                        SELECT lower(nome_parlamentar) as nome FROM senado.parlamentar
-                    )
-                    SELECT e.funcao, SUM(e.valor_pago) as valor_total
-                    FROM portal.emendas e
-                    JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
-                    GROUP BY e.funcao
-                    ORDER BY valor_total DESC
-                """
-                cursor.execute(query_areas)
-            
-            areas_raw = cursor.fetchall()
 
+            base_cte = f"""
+                WITH senadores_nomes AS (
+                    SELECT codigo as id, lower(nome_completo) as nome FROM senado.parlamentar
+                    UNION
+                    SELECT codigo as id, lower(nome_parlamentar) as nome FROM senado.parlamentar
+                ),
+                emendas_base AS (
+                    SELECT
+                        e.valor_pago,
+                        e.localidade_gasto,
+                        e.funcao,
+                        p.codigo,
+                        p.nome_parlamentar,
+                        p.sigla_partido,
+                        p.uf,
+                        p.url_foto
+                    FROM portal.emendas e
+                    JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
+                    JOIN senado.parlamentar p ON s.id = p.codigo
+                    WHERE {where_base}
+                )
+            """
+
+            # 1. Totais gerais
+            query_totais = base_cte + """
+                SELECT
+                    COUNT(DISTINCT codigo) as total_senadores,
+                    COUNT(DISTINCT localidade_gasto) as total_municipios,
+                    COUNT(DISTINCT funcao) as total_areas,
+                    COALESCE(SUM(valor_pago), 0) as valor_total
+                FROM emendas_base
+            """
+            cursor.execute(query_totais, tuple(params_base))
+            totais_row = cursor.fetchone()
+
+            valor_total_real = float(totais_row[3]) if totais_row and totais_row[3] else 0.0
+            base_percentual = valor_total_real if valor_total_real > 0 else 1.0
+
+            # 2. Distribuição por área
+            query_areas = base_cte + """
+                SELECT funcao, SUM(valor_pago) as valor_total
+                FROM emendas_base
+                GROUP BY funcao
+                ORDER BY valor_total DESC
+            """
+            cursor.execute(query_areas, tuple(params_base))
+            areas_raw = cursor.fetchall()
             areas_formatadas = [
                 {
                     "nome": r[0] if r[0] else "Outros",
                     "valor": float(r[1]),
-                    "percentual": round((float(r[1]) / valor_total_global) * 100, 1)
+                    "percentual": round((float(r[1]) / base_percentual) * 100, 1)
                 }
                 for r in areas_raw
             ]
 
-            # 3. Top 10 Senadores (Optimized with CTE)
-            if legislatura:
-                query_top = """
-                    WITH senadores_nomes AS (
-                        SELECT codigo as id, lower(nome_completo) as nome FROM senado.parlamentar
-                        UNION
-                        SELECT codigo as id, lower(nome_parlamentar) as nome FROM senado.parlamentar
-                    )
-                    SELECT 
-                        p.codigo, p.nome_parlamentar, p.sigla_partido, p.uf, p.url_foto,
-                        SUM(e.valor_pago) as total_valor
-                    FROM portal.emendas e
-                    JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
-                    JOIN senado.parlamentar p ON s.id = p.codigo
-                    WHERE CAST(e.ano AS INTEGER) BETWEEN %s AND %s
-                      AND EXISTS (
-                          SELECT 1 FROM senado.mandato m 
-                          WHERE m.codigo_parlamentar = p.codigo 
-                          AND (
-                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 + 3
-                              OR
-                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 + 3
-                          )
-                      )
-                    GROUP BY p.codigo, p.nome_parlamentar, p.sigla_partido, p.uf, p.url_foto
-                    ORDER BY total_valor DESC
-                    LIMIT 10
-                """
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                cursor.execute(query_top, (start_year, end_year))
-            else:
-                query_top = """
-                    WITH senadores_nomes AS (
-                        SELECT codigo as id, lower(nome_completo) as nome FROM senado.parlamentar
-                        UNION
-                        SELECT codigo as id, lower(nome_parlamentar) as nome FROM senado.parlamentar
-                    )
-                    SELECT 
-                        p.codigo, p.nome_parlamentar, p.sigla_partido, p.uf, p.url_foto,
-                        SUM(e.valor_pago) as total_valor
-                    FROM portal.emendas e
-                    JOIN senadores_nomes s ON lower(e.nome_autor) = s.nome
-                    JOIN senado.parlamentar p ON s.id = p.codigo
-                    WHERE EXISTS (
-                          SELECT 1 FROM senado.mandato m 
-                          WHERE m.codigo_parlamentar = p.codigo 
-                          AND (
-                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 + 3
-                              OR
-                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 + 3
-                          )
-                      )
-                    GROUP BY p.codigo, p.nome_parlamentar, p.sigla_partido, p.uf, p.url_foto
-                    ORDER BY total_valor DESC
-                    LIMIT 10
-                """
-                cursor.execute(query_top)
-            
+            # 3. Top 10 senadores
+            query_top = base_cte + """
+                SELECT
+                    codigo, nome_parlamentar, sigla_partido, uf, url_foto,
+                    SUM(valor_pago) as total_valor
+                FROM emendas_base
+                GROUP BY codigo, nome_parlamentar, sigla_partido, uf, url_foto
+                ORDER BY total_valor DESC
+                LIMIT 10
+            """
+            cursor.execute(query_top, tuple(params_base))
             top_senadores = cursor.fetchall()
 
             return {
@@ -1084,7 +1095,7 @@ def get_resumo_emendas(legislatura: int):
                     "senadores": totais_row[0],
                     "municipios": totais_row[1],
                     "areas": totais_row[2],
-                    "valor_total": valor_total_global
+                    "valor_total": valor_total_real
                 },
                 "areas": areas_formatadas,
                 "ranking": [
@@ -1177,37 +1188,57 @@ def get_emendas_lista_senador(legislatura: int, senador_codigo: int, pagina: int
             raise HTTPException(status_code=503, detail="Banco de dados indisponível")
         
         with conn.cursor() as cursor:
+            filtros_base = []
+            params_base = [senador_codigo]
+
+            if legislatura:
+                start_year, end_year = _periodo_legislatura(legislatura)
+                filtros_base.append("CAST(e.ano AS INTEGER) BETWEEN %s AND %s")
+                params_base.extend([start_year, end_year])
+                filtros_base.append("""
+                    EXISTS (
+                        SELECT 1
+                        FROM senado.mandato m
+                        WHERE m.codigo_parlamentar = s.codigo
+                          AND (m.primeira_legislatura = %s OR m.segunda_legislatura = %s)
+                    )
+                """)
+                params_base.extend([str(legislatura), str(legislatura)])
+            else:
+                filtros_base.append("""
+                    EXISTS (
+                        SELECT 1
+                        FROM senado.mandato m
+                        WHERE m.codigo_parlamentar = s.codigo
+                          AND (
+                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4
+                                                         AND 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 + 3
+                              OR
+                              CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4
+                                                         AND 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 + 3
+                          )
+                    )
+                """)
+
+            where_clause = " AND ".join(filtros_base)
+
             # 1. Total para paginação
-            query_count = """
+            query_count = f"""
                 SELECT COUNT(*)
                 FROM portal.emendas e
                 JOIN senado.parlamentar s 
                    ON (lower(e.nome_autor) = lower(s.nome_completo) 
                        OR lower(e.nome_autor) = lower(s.nome_parlamentar))
                 WHERE s.codigo = %s
-                  AND EXISTS (
-                      SELECT 1 FROM senado.mandato m 
-                      WHERE m.codigo_parlamentar = s.codigo 
-                      AND (
-                          CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 + 3
-                          OR
-                          CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 + 3
-                      )
-                  )
+                  AND {where_clause}
             """
-            params_count = [senador_codigo]
-            if legislatura:
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                query_count += " AND CAST(e.ano AS INTEGER) BETWEEN %s AND %s"
-                params_count.extend([start_year, end_year])
 
-            cursor.execute(query_count, tuple(params_count))
+            cursor.execute(query_count, tuple(params_base))
             total_items = cursor.fetchone()[0]
             total_paginas = (total_items + itens_per_page - 1) // itens_per_page
 
             # 2. Dados paginados (Seleção Seletiva)
-            query = """
+            query = f"""
                 SELECT 
                     e.codigo_emenda as codigo,
                     e.ano,
@@ -1220,25 +1251,10 @@ def get_emendas_lista_senador(legislatura: int, senador_codigo: int, pagina: int
                   ON (lower(e.nome_autor) = lower(s.nome_completo) 
                       OR lower(e.nome_autor) = lower(s.nome_parlamentar))
                 WHERE s.codigo = %s
-                  AND EXISTS (
-                      SELECT 1 FROM senado.mandato m 
-                      WHERE m.codigo_parlamentar = s.codigo 
-                      AND (
-                          CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.primeira_legislatura AS INTEGER)) * 4 + 3
-                          OR
-                          CAST(e.ano AS INTEGER) BETWEEN 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 AND 2023 - (57 - CAST(m.segunda_legislatura AS INTEGER)) * 4 + 3
-                      )
-                  )
+                  AND {where_clause}
             """
-            params = [senador_codigo]
-            if legislatura:
-                start_year = 2023 - (57 - legislatura) * 4
-                end_year = start_year + 3
-                query += " AND CAST(e.ano AS INTEGER) BETWEEN %s AND %s"
-                params.extend([start_year, end_year])
-
-            query += " ORDER BY e.ano DESC, e.valor_pago DESC LIMIT %s OFFSET %s"
-            params.extend([itens_per_page, offset])
+            query += " ORDER BY CAST(e.ano AS INTEGER) DESC, e.valor_pago DESC LIMIT %s OFFSET %s"
+            params = [*params_base, itens_per_page, offset]
             cursor.execute(query, tuple(params))
             res = cursor.fetchall()
             

--- a/backend/api/senado/router.py
+++ b/backend/api/senado/router.py
@@ -57,11 +57,14 @@ def get_lista_senadores(legislatura: int):
         
         with conn.cursor() as cursor:
             query = """
-                SELECT DISTINCT ON (p.codigo)
+                SELECT
                     p.codigo,
                     p.nome_parlamentar,
                     p.sigla_partido,
-                    p.uf,
+                    COALESCE(
+                        NULLIF(TRIM(p.uf::text), ''),
+                        NULLIF(TRIM(MAX(m.uf)::text), '')
+                    ) AS uf,
                     p.url_foto
                 FROM senado.parlamentar p
                 INNER JOIN senado.mandato m ON p.codigo = m.codigo_parlamentar
@@ -71,7 +74,10 @@ def get_lista_senadores(legislatura: int):
                 query += " WHERE m.primeira_legislatura = %s OR m.segunda_legislatura = %s"
                 params.extend([str(legislatura), str(legislatura)])
                 
-            query += " ORDER BY p.codigo, p.nome_parlamentar ASC"
+            query += """
+                GROUP BY p.codigo, p.nome_parlamentar, p.sigla_partido, p.uf, p.url_foto
+                ORDER BY p.codigo, p.nome_parlamentar ASC
+            """
             cursor.execute(query, tuple(params))
             
             resultados = cursor.fetchall()
@@ -142,26 +148,39 @@ def get_estatisticas_senado(legislatura: int):
 
             # Distribuição por Região
             query_regiao = """
-                SELECT 
-                    CASE
-                        WHEN p.uf IN ('AC','AP','AM','PA','RO','RR','TO') THEN 'Norte'
-                        WHEN p.uf IN ('AL','BA','CE','MA','PB','PE','PI','RN','SE') THEN 'Nordeste'
-                        WHEN p.uf IN ('DF','GO','MT','MS') THEN 'Centro-Oeste'
-                        WHEN p.uf IN ('ES','MG','RJ','SP') THEN 'Sudeste'
-                        WHEN p.uf IN ('PR','RS','SC') THEN 'Sul'
-                        ELSE 'Outros'
-                    END AS regiao,
-                    COUNT(DISTINCT p.codigo) AS quantidade
-                FROM senado.parlamentar p
-                INNER JOIN senado.mandato m ON p.codigo = m.codigo_parlamentar
-                WHERE 1=1
+                WITH base_senadores AS (
+                    SELECT
+                        p.codigo,
+                        COALESCE(
+                            NULLIF(TRIM(MAX(p.uf)::text), ''),
+                            NULLIF(TRIM(MAX(m.uf)::text), '')
+                        ) AS uf_ref
+                    FROM senado.parlamentar p
+                    INNER JOIN senado.mandato m ON p.codigo = m.codigo_parlamentar
+                    WHERE 1=1
             """
             params_reg = []
             if legislatura:
                 query_regiao += " AND (m.primeira_legislatura = %s OR m.segunda_legislatura = %s)"
                 params_reg.extend([str(legislatura), str(legislatura)])
                 
-            query_regiao += " GROUP BY regiao ORDER BY quantidade DESC"
+            query_regiao += """
+                    GROUP BY p.codigo
+                )
+                SELECT 
+                    CASE
+                        WHEN uf_ref IN ('AC','AP','AM','PA','RO','RR','TO') THEN 'Norte'
+                        WHEN uf_ref IN ('AL','BA','CE','MA','PB','PE','PI','RN','SE') THEN 'Nordeste'
+                        WHEN uf_ref IN ('DF','GO','MT','MS') THEN 'Centro-Oeste'
+                        WHEN uf_ref IN ('ES','MG','RJ','SP') THEN 'Sudeste'
+                        WHEN uf_ref IN ('PR','RS','SC') THEN 'Sul'
+                        ELSE 'Outros'
+                    END AS regiao,
+                    COUNT(*) AS quantidade
+                FROM base_senadores
+                GROUP BY regiao
+                ORDER BY quantidade DESC
+            """
             cursor.execute(query_regiao, tuple(params_reg))
             regioes = cursor.fetchall()
             
@@ -249,9 +268,16 @@ WHERE d.cod_senador IN (%s, %s)
     data_despesa
 FROM senado.despesa_ceaps
 WHERE cod_senador = %s
-  AND data_despesa >= CURRENT_DATE - INTERVAL '12 months'
-ORDER BY data_despesa DESC;
+ORDER BY
+    COALESCE(
+        data_despesa,
+        TO_DATE(CAST(ano AS TEXT) || '-' || LPAD(CAST(mes AS TEXT), 2, '0') || '-01', 'YYYY-MM-DD')
+    ) DESC,
+    CAST(ano AS INTEGER) DESC,
+    CAST(mes AS INTEGER) DESC
+LIMIT 12;
 """
+
             cursor.execute(query_despesas_recentes, (id1,))
             despesas_recentes_1 = cursor.fetchall()
             cursor.execute(query_despesas_recentes, (id2,))
@@ -317,6 +343,8 @@ ORDER BY data_despesa DESC;
                     for r in despesas_recentes_2
                 ]       
             }
+    except HTTPException:
+        raise
     except Exception as e:
         logging.error(f"Erro ao buscar senador: {e}")
         raise HTTPException(status_code=500, detail="Erro ao processar senador")
@@ -648,12 +676,14 @@ def get_despesas_estatisticas(legislatura: int):
             # 6. Evolução Mensal (últimos 12 meses registrados na legislatura ou total)
             query_evolucao = f"""
                 SELECT 
-                    EXTRACT(YEAR FROM d.data_despesa)::int AS ano,
-                    EXTRACT(MONTH FROM d.data_despesa)::int AS mes,
+                    d.ano AS ano,
+                    d.mes AS mes,
                     SUM(d.valor_reembolsado) AS valor
                 FROM senado.despesa_ceaps d
                 {join_mandato}
-                WHERE d.data_despesa IS NOT NULL {where_leg}
+                WHERE d.mes BETWEEN 1 AND 12
+                  AND make_date(d.ano, d.mes, 1) <= date_trunc('month', CURRENT_DATE)::date
+                  {where_leg}
                 GROUP BY 1, 2
                 ORDER BY 1 DESC, 2 DESC
                 LIMIT 12

--- a/frontend/src/components/camara/ProjetosLegislativosList.vue
+++ b/frontend/src/components/camara/ProjetosLegislativosList.vue
@@ -15,7 +15,7 @@
     <!-- Lista -->
     <div v-else class="space-y-4">
       <div
-        v-for="projeto in displayedProjetos"
+        v-for="projeto in store.projetosLegislativosList"
         :key="projeto.id"
       >
         <BaseCard
@@ -206,18 +206,13 @@ import BaseBadge from '@/components/ui/BaseBadge.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import { useCamaraStore } from '@/stores/camara'
 import type { VotoDeputado } from '@/stores/camara'
-import { computed } from 'vue'
 
 const store = useCamaraStore()
 const expandedVotacaoIds = ref<Set<string>>(new Set())
 
-const displayedProjetos = computed(() => {
-  return store.projetosLegislativosList.slice(0, store.displayedProjetosCount)
-})
-
 onMounted(() => {
   if (store.projetosLegislativosList.length === 0) {
-    store.fetchProjetosLegislativos()
+    store.fetchProjetosLegislativos(1)
   }
 })
 

--- a/frontend/src/components/camara/Stats.vue
+++ b/frontend/src/components/camara/Stats.vue
@@ -24,7 +24,7 @@
             </div>
             <div>
               <p class="text-sm text-muted-foreground">Regiões</p>
-              <p class="text-2xl font-bold text-foreground">5</p>
+              <p class="text-2xl font-bold text-foreground">{{ totalRegioes || '...' }}</p>
             </div>
           </div>
         </BaseCard>
@@ -50,7 +50,7 @@
             </div>
             <div>
               <p class="text-sm text-muted-foreground">Estados (UF)</p>
-              <p class="text-2xl font-bold text-foreground">27</p>
+              <p class="text-2xl font-bold text-foreground">{{ totalUfs || '...' }}</p>
             </div>
           </div>
         </BaseCard>
@@ -156,6 +156,16 @@ const mesesPtBr: Record<number, string> = {
 }
 
 const chartColors = ['bg-chart-1', 'bg-chart-2', 'bg-chart-3', 'bg-chart-4', 'bg-chart-5']
+
+const totalRegioes = computed(() => {
+  if (store.deputadoStats?.total_regioes !== undefined) return store.deputadoStats.total_regioes
+  return store.deputadoStats?.deputados_por_regiao?.length ?? 0
+})
+
+const totalUfs = computed(() => {
+  if (store.deputadoStats?.total_ufs !== undefined) return store.deputadoStats.total_ufs
+  return store.estadosUnicos.length
+})
 
 const gastosUltimosMeses = computed(() => {
   if (!store.generalStats?.gastos_por_mes) return []

--- a/frontend/src/components/senado/ProjetosLegislativosList.vue
+++ b/frontend/src/components/senado/ProjetosLegislativosList.vue
@@ -2,7 +2,7 @@
   <div>
     <!-- Results count -->
     <p class="text-sm text-muted-foreground mb-4">
-      {{ store.filteredProjetosLegislativos.length }} projetos legislativos encontrados
+      {{ store.totalProjetosLegislativos.toLocaleString('pt-BR') }} projetos legislativos encontrados
     </p>
 
     <!-- Loading -->
@@ -187,6 +187,17 @@
           </div>
         </div>
       </div>
+    </div>
+
+    <!-- Load more -->
+    <div v-if="store.hasMoreProjetosLegislativos && store.projetosLegislativosList.length > 0" class="flex justify-center mt-8">
+      <button
+        @click="store.loadMoreProjetosLegislativos()"
+        class="px-6 py-3 rounded-lg border border-border bg-background text-foreground font-medium hover:bg-muted transition-colors inline-flex items-center gap-2"
+      >
+        <span>Carregar mais</span>
+        <ChevronDown class="h-4 w-4" />
+      </button>
     </div>
   </div>
 </template>

--- a/frontend/src/components/senado/ProjetosLegislativosStats.vue
+++ b/frontend/src/components/senado/ProjetosLegislativosStats.vue
@@ -9,7 +9,7 @@
             </div>
             <div>
               <p class="text-sm text-muted-foreground">Total de Projetos Legislativos</p>
-              <p class="text-2xl font-bold text-foreground">{{ store.filteredProjetosLegislativos.length }}</p>
+              <p class="text-2xl font-bold text-foreground">{{ store.totalProjetosLegislativos.toLocaleString('pt-BR') }}</p>
             </div>
           </div>
         </BaseCard>

--- a/frontend/src/components/senado/Stats.vue
+++ b/frontend/src/components/senado/Stats.vue
@@ -24,7 +24,7 @@
             </div>
             <div>
               <p class="text-sm text-muted-foreground">Regiões</p>
-              <p class="text-2xl font-bold text-foreground">5</p>
+              <p class="text-2xl font-bold text-foreground">{{ store.senadorStats?.total_regioes || '...' }}</p>
             </div>
           </div>
         </BaseCard>
@@ -162,7 +162,9 @@ const chartColors = ['bg-chart-1', 'bg-chart-2', 'bg-chart-3', 'bg-chart-4', 'bg
 const gastosUltimosMeses = computed(() => {
   if (!store.generalStats?.gastos_por_mes) return []
 
-  const ultimos = [...store.generalStats.gastos_por_mes].reverse().slice(0, 5).reverse()
+  const ultimos = [...store.generalStats.gastos_por_mes]
+    .sort((a, b) => (b.ano - a.ano) || (b.mes - a.mes))
+    .slice(0, 5)
   const maxValor = Math.max(...ultimos.map(m => m.valor), 1)
 
   return ultimos.map((m, i) => ({

--- a/frontend/src/components/ui/HeroLegislaturaSelect.vue
+++ b/frontend/src/components/ui/HeroLegislaturaSelect.vue
@@ -29,9 +29,9 @@ const loadingStore = useLoadingStore()
 
 const formatLegislatura = (legis: number) => {
   if (legis === 0) return 'Todas as legislaturas'
-  // Calculates the start year. 57th started in 2023, each legislature is 4 years.
+  // 57ª inicia em 2023 e cada legislatura cobre 4 anos corridos (ex.: 2023-2026).
   const startYear = 2023 - (57 - legis) * 4
-  const endYear = startYear + 4
+  const endYear = startYear + 3
   return `${legis}ª (${startYear}-${endYear})`
 }
 

--- a/frontend/src/pages/camara/CamaraComparacaoPage.vue
+++ b/frontend/src/pages/camara/CamaraComparacaoPage.vue
@@ -255,7 +255,8 @@
                   <p class="mt-1 text-3xl font-bold" :class="totalA <= totalB ? 'text-green-600' : 'text-red-500'">
                     R$ {{ formatCurrency(totalA) }}
                   </p>
-                  <BaseBadge v-if="totalA <= totalB" variant="success" class="mt-2">Menor gasto</BaseBadge>
+                  <BaseBadge v-if="totalA === totalB" variant="secondary" class="mt-2">Empate</BaseBadge>
+                  <BaseBadge v-else-if="totalA <= totalB" variant="success" class="mt-2">Menor gasto</BaseBadge>
                   <BaseBadge v-else variant="destructive" class="mt-2">Maior gasto</BaseBadge>
                 </div>
               </BaseCard>
@@ -265,7 +266,8 @@
                   <p class="mt-1 text-3xl font-bold" :class="totalB <= totalA ? 'text-green-600' : 'text-red-500'">
                     R$ {{ formatCurrency(totalB) }}
                   </p>
-                  <BaseBadge v-if="totalB <= totalA" variant="success" class="mt-2">Menor gasto</BaseBadge>
+                  <BaseBadge v-if="totalA === totalB" variant="secondary" class="mt-2">Empate</BaseBadge>
+                  <BaseBadge v-else-if="totalB <= totalA" variant="success" class="mt-2">Menor gasto</BaseBadge>
                   <BaseBadge v-else variant="destructive" class="mt-2">Maior gasto</BaseBadge>
                 </div>
               </BaseCard>
@@ -278,10 +280,7 @@
                 <p class="mt-1 text-2xl font-bold text-foreground">
                   R$ {{ formatCurrency(Math.abs(totalA - totalB)) }}
                 </p>
-                <p class="mt-1 text-sm text-muted-foreground">
-                  <span class="font-medium text-foreground">{{ totalA > totalB ? deputadoA.nome_civil : deputadoB.nome_civil }}</span>
-                  gastou {{ percentDiff }}% a mais
-                </p>
+                <p class="mt-1 text-sm text-muted-foreground">{{ differenceSummary }}</p>
               </div>
             </BaseCard>
           </div>
@@ -616,7 +615,24 @@ const formatCurrencyShort = (value: number): string => {
 
 const percentDiff = computed(() => {
   const min = Math.min(totalA.value, totalB.value)
-  if (min === 0) return '0'
+  if (min <= 0) return null
   return (((Math.abs(totalA.value - totalB.value)) / min) * 100).toFixed(1)
+})
+
+const differenceSummary = computed(() => {
+  if (!deputadoA.value || !deputadoB.value) return ''
+
+  if (totalA.value === totalB.value) {
+    return 'Os dois tiveram o mesmo total de gastos.'
+  }
+
+  const deputadoMaiorGasto = totalA.value > totalB.value ? deputadoA.value.nome_civil : deputadoB.value.nome_civil
+  const deputadoMenorGasto = totalA.value > totalB.value ? deputadoB.value.nome_civil : deputadoA.value.nome_civil
+
+  if (percentDiff.value === null) {
+    return `${deputadoMaiorGasto} registrou despesas, enquanto ${deputadoMenorGasto} não teve gastos no período selecionado.`
+  }
+
+  return `${deputadoMaiorGasto} gastou ${percentDiff.value}% a mais.`
 })
 </script>

--- a/frontend/src/pages/camara/CamaraDetalhePage.vue
+++ b/frontend/src/pages/camara/CamaraDetalhePage.vue
@@ -24,9 +24,9 @@
                 </option>
               </template>
               <template v-else>
-                <option :value="57">57ª Legislatura (2023-2027)</option>
-                <option :value="56">56ª Legislatura (2019-2023)</option>
-                <option :value="55">55ª Legislatura (2015-2019)</option>
+                <option :value="57">57ª Legislatura (2023-2026)</option>
+                <option :value="56">56ª Legislatura (2019-2022)</option>
+                <option :value="55">55ª Legislatura (2015-2018)</option>
               </template>
             </select>
           </div>
@@ -262,7 +262,7 @@ const formatDate = (dateString: string) => {
 const formatLegislatura = (legis: number) => {
   if (legis === 0) return 'Todas as legislaturas (Histórico)'
   const startYear = 2023 - (57 - legis) * 4
-  const endYear = startYear + 4
+  const endYear = startYear + 3
   return `${legis}ª Legislatura (${startYear}-${endYear})`
 }
 

--- a/frontend/src/pages/senado/SenadoComparacaoPage.vue
+++ b/frontend/src/pages/senado/SenadoComparacaoPage.vue
@@ -247,7 +247,8 @@
                   <p class="mt-1 text-3xl font-bold" :class="totalA <= totalB ? 'text-green-600' : 'text-red-500'">
                     R$ {{ formatCurrency(totalA) }}
                   </p>
-                  <BaseBadge v-if="totalA <= totalB" variant="success" class="mt-2">Menor gasto</BaseBadge>
+                  <BaseBadge v-if="totalA === totalB" variant="secondary" class="mt-2">Empate</BaseBadge>
+                  <BaseBadge v-else-if="totalA <= totalB" variant="success" class="mt-2">Menor gasto</BaseBadge>
                   <BaseBadge v-else variant="destructive" class="mt-2">Maior gasto</BaseBadge>
                 </div>
               </BaseCard>
@@ -257,7 +258,8 @@
                   <p class="mt-1 text-3xl font-bold" :class="totalB <= totalA ? 'text-green-600' : 'text-red-500'">
                     R$ {{ formatCurrency(totalB) }}
                   </p>
-                  <BaseBadge v-if="totalB <= totalA" variant="success" class="mt-2">Menor gasto</BaseBadge>
+                  <BaseBadge v-if="totalA === totalB" variant="secondary" class="mt-2">Empate</BaseBadge>
+                  <BaseBadge v-else-if="totalB <= totalA" variant="success" class="mt-2">Menor gasto</BaseBadge>
                   <BaseBadge v-else variant="destructive" class="mt-2">Maior gasto</BaseBadge>
                 </div>
               </BaseCard>
@@ -270,10 +272,7 @@
                 <p class="mt-1 text-2xl font-bold text-foreground">
                   R$ {{ formatCurrency(Math.abs(totalA - totalB)) }}
                 </p>
-                <p class="mt-1 text-sm text-muted-foreground">
-                  <span class="font-medium text-foreground">{{ totalA > totalB ? senadorA.nome_civil : senadorB.nome_civil }}</span>
-                  gastou {{ percentDiff }}% a mais
-                </p>
+                <p class="mt-1 text-sm text-muted-foreground">{{ differenceSummary }}</p>
               </div>
             </BaseCard>
           </div>
@@ -610,7 +609,24 @@ const formatCurrencyShort = (value: number): string => {
 
 const percentDiff = computed(() => {
   const min = Math.min(totalA.value, totalB.value)
-  if (min === 0) return '0'
+  if (min <= 0) return null
   return (((Math.abs(totalA.value - totalB.value)) / min) * 100).toFixed(1)
+})
+
+const differenceSummary = computed(() => {
+  if (!senadorA.value || !senadorB.value) return ''
+
+  if (totalA.value === totalB.value) {
+    return 'Os dois tiveram o mesmo total de gastos.'
+  }
+
+  const senadorMaiorGasto = totalA.value > totalB.value ? senadorA.value.nome_civil : senadorB.value.nome_civil
+  const senadorMenorGasto = totalA.value > totalB.value ? senadorB.value.nome_civil : senadorA.value.nome_civil
+
+  if (percentDiff.value === null) {
+    return `${senadorMaiorGasto} registrou despesas, enquanto ${senadorMenorGasto} não teve gastos no período selecionado.`
+  }
+
+  return `${senadorMaiorGasto} gastou ${percentDiff.value}% a mais.`
 })
 </script>

--- a/frontend/src/pages/senado/SenadoDespesasPage.vue
+++ b/frontend/src/pages/senado/SenadoDespesasPage.vue
@@ -269,16 +269,14 @@ const allPieSegments = computed(() => {
 // ── Categorias ──────────────────────────────────────────────────────────────
 const categoriasAgregadas = computed(() => {
   if (!store.generalStats?.categorias?.length) return []
-  const maxValor = store.generalStats.categorias[0]?.total || 1
   const totalCats = store.generalStats.categorias.reduce((s, c) => s + c.total, 0) || 1
   return store.generalStats.categorias.map(c => ({
-    nome: c.categoria,
+    nome: c.categoria || 'Não informado',
     total: c.total,
     valorFormatado: c.total >= 1000000
       ? `R$ ${(c.total / 1000000).toLocaleString('pt-BR', { maximumFractionDigits: 1 })}M`
       : `R$ ${(c.total / 1000).toLocaleString('pt-BR', { maximumFractionDigits: 0 })} mil`,
-    percentual: (c.total / maxValor) * 100,
-    percentualTotal: (c.total / totalCats) * 100
+    percentual: (c.total / totalCats) * 100
   }))
 })
 

--- a/frontend/src/pages/senado/SenadoDetalhePage.vue
+++ b/frontend/src/pages/senado/SenadoDetalhePage.vue
@@ -24,9 +24,9 @@
                 </option>
               </template>
               <template v-else>
-                <option :value="57">57ª Legislatura (2023-2027)</option>
-                <option :value="56">56ª Legislatura (2019-2023)</option>
-                <option :value="55">55ª Legislatura (2015-2019)</option>
+                <option :value="57">57ª Legislatura (2023-2026)</option>
+                <option :value="56">56ª Legislatura (2019-2022)</option>
+                <option :value="55">55ª Legislatura (2015-2018)</option>
               </template>
             </select>
           </div>
@@ -307,7 +307,7 @@ const formatDate = (dateString: string) => {
 const formatLegislatura = (legis: number) => {
   if (legis === 0) return 'Todas as legislaturas (Histórico)'
   const startYear = 2023 - (57 - legis) * 4
-  const endYear = startYear + 4
+  const endYear = startYear + 3
   return `${legis}ª Legislatura (${startYear}-${endYear})`
 }
 

--- a/frontend/src/stores/camara.ts
+++ b/frontend/src/stores/camara.ts
@@ -82,6 +82,8 @@ export interface EstatisticasGerais {
 
 export interface EstatisticasDeputado {
   total_deputados: number
+  total_regioes?: number
+  total_ufs?: number
   deputados_por_regiao: { name: string; value: number }[]
 }
 
@@ -178,10 +180,9 @@ export const useCamaraStore = defineStore("camara", () => {
   const projetosLegislativosList = ref<ProjetoLegislativo[]>([])
   const totalProjetosLegislativos = ref(0)
   const loadingProjetosLegislativos = ref(false)
-  const displayedProjetosCount = ref(15)
-  const hasMoreProjetosLegislativos = computed(() => {
-    return displayedProjetosCount.value < projetosLegislativosList.value.length
-  })
+  const projetosLegislativosDistribuicao = ref<{ tipo: string; quantidade: number }[]>([])
+  const projetosLegislativosPage = ref(1)
+  const hasMoreProjetosLegislativos = ref(true)
 
   // Votos state
   const currentVotos = ref<VotosProjetoLegislativo | null>(null)
@@ -268,14 +269,14 @@ export const useCamaraStore = defineStore("camara", () => {
   }
 
 
-  const fetchProjetosLegislativos = async () => {
+  const fetchProjetosLegislativos = async (pagina = 1) => {
     loadingProjetosLegislativos.value = true
     error.value = null
-    displayedProjetosCount.value = 15 // Reset display count on new fetch
 
     try {
       const params = new URLSearchParams()
-      params.append("limite", "1000") // Fetch a large amount for stats
+      params.append("pagina", String(pagina))
+      params.append("limite", "15")
 
       if (projetosLegislativosFilters.value.siglaTipo) {
         params.append("siglaTipo", projetosLegislativosFilters.value.siglaTipo)
@@ -294,8 +295,28 @@ export const useCamaraStore = defineStore("camara", () => {
       if (!response.ok) throw new Error("Falha ao buscar projetos legislativos")
 
       const data = await response.json()
-      projetosLegislativosList.value = data.proposicoes || []
+      const mapped = (data.proposicoes || []).map((p: any) => ({
+        id: p.id,
+        siglaTipo: p.siglaTipo,
+        numero: p.numero,
+        ano: p.ano,
+        ementa: p.ementa,
+        dataApresentacao: p.dataApresentacao,
+        autor_principal: p.autor_principal || "Desconhecido",
+      }))
+
+      if (pagina === 1) {
+        projetosLegislativosList.value = mapped
+        selectedProjetoLegislativoId.value = null
+        currentVotos.value = null
+      } else {
+        projetosLegislativosList.value = [...projetosLegislativosList.value, ...mapped]
+      }
+
       totalProjetosLegislativos.value = data.paginacao?.total || 0
+      projetosLegislativosDistribuicao.value = data.estatisticas?.distribuicao_tipos || []
+      projetosLegislativosPage.value = pagina
+      hasMoreProjetosLegislativos.value = projetosLegislativosList.value.length < totalProjetosLegislativos.value
     } catch (e: any) {
       console.error("Erro ao buscar projetos legislativos:", e)
       error.value = "Erro ao carregar projetos legislativos."
@@ -304,12 +325,14 @@ export const useCamaraStore = defineStore("camara", () => {
     }
   }
 
-  const loadMoreProjetosLegislativos = () => {
-    displayedProjetosCount.value += 15
+  const loadMoreProjetosLegislativos = async () => {
+    if (!loadingProjetosLegislativos.value && hasMoreProjetosLegislativos.value) {
+      await fetchProjetosLegislativos(projetosLegislativosPage.value + 1)
+    }
   }
 
   const tiposUnicosProjetosLegislativos = computed(() => {
-    const tipos = new Set(projetosLegislativosList.value.map((p) => p.siglaTipo))
+    const tipos = new Set(projetosLegislativosDistribuicao.value.map((p) => p.tipo))
     return Array.from(tipos).sort()
   })
 
@@ -318,15 +341,7 @@ export const useCamaraStore = defineStore("camara", () => {
     return Array.from(anos).sort((a, b) => b - a)
   })
 
-  const projetosLegislativosPorTipo = computed(() => {
-    const contagem: Record<string, number> = {}
-    projetosLegislativosList.value.forEach((p) => {
-      contagem[p.siglaTipo] = (contagem[p.siglaTipo] || 0) + 1
-    })
-    return Object.entries(contagem)
-      .map(([tipo, quantidade]) => ({ tipo, quantidade }))
-      .sort((a, b) => b.quantidade - a.quantidade)
-  })
+  const projetosLegislativosPorTipo = computed(() => projetosLegislativosDistribuicao.value)
 
   const fetchVotosProjetoLegislativo = async (id: number) => {
     loadingVotos.value = true
@@ -364,12 +379,12 @@ export const useCamaraStore = defineStore("camara", () => {
 
   const setProjetosLegislativosFilter = (key: keyof ProjetosLegislativosFilters, value: string) => {
     projetosLegislativosFilters.value[key] = value
-    fetchProjetosLegislativos()
+    fetchProjetosLegislativos(1)
   }
 
   const resetProjetosLegislativosFilters = () => {
     projetosLegislativosFilters.value = { search: "", siglaTipo: "", ano: "", deputado: "" }
-    fetchProjetosLegislativos()
+    fetchProjetosLegislativos(1)
   }
 
   const partidosUnicos = computed(() => {
@@ -424,7 +439,7 @@ export const useCamaraStore = defineStore("camara", () => {
       fetchDeputados(),
       fetchEstatisticasGerais(),
       fetchEstatisticasDeputados(),
-      fetchProjetosLegislativos()
+      fetchProjetosLegislativos(1)
     ])
   }
 
@@ -464,7 +479,6 @@ export const useCamaraStore = defineStore("camara", () => {
     totalProjetosLegislativos,
     loadingProjetosLegislativos,
     hasMoreProjetosLegislativos,
-    displayedProjetosCount,
     projetosLegislativosFilters,
     fetchProjetosLegislativos,
     loadMoreProjetosLegislativos,

--- a/frontend/src/stores/senado.ts
+++ b/frontend/src/stores/senado.ts
@@ -165,6 +165,8 @@ export const useSenadoStore = defineStore("senado", () => {
         senador: "",
     })
     const projetosLegislativosList = ref<ProjetoLegislativoSenado[]>([])
+    const totalProjetosLegislativos = ref(0)
+    const projetosLegislativosDistribuicao = ref<{ tipo: string; quantidade: number }[]>([])
     const loadingProjetosLegislativos = ref(false)
     const projetosLegislativosPage = ref(1)
     const hasMoreProjetosLegislativos = ref(true)
@@ -356,9 +358,11 @@ export const useSenadoStore = defineStore("senado", () => {
 
     const fetchProjetosLegislativos = async (pagina = 1) => {
         loadingProjetosLegislativos.value = true
+        error.value = null
         try {
             const params = new URLSearchParams()
             params.append("pagina", String(pagina))
+            params.append("limite", "15")
 
             if (projetosLegislativosFilters.value.siglaTipo) {
                 params.append("siglaTipo", projetosLegislativosFilters.value.siglaTipo)
@@ -377,7 +381,7 @@ export const useSenadoStore = defineStore("senado", () => {
             if (!response.ok) throw new Error("Falha ao buscar projetos legislativos")
             const data = await response.json()
 
-            const mapped = data.materia.map((m: any) => ({
+            const mapped = (data.materia || []).map((m: any) => ({
                 id: m.id,
                 siglaTipo: m.siglaTipo,
                 numero: m.numero,
@@ -389,14 +393,19 @@ export const useSenadoStore = defineStore("senado", () => {
 
             if (pagina === 1) {
                 projetosLegislativosList.value = mapped
+                selectedProjetoLegislativoId.value = null
+                currentVotos.value = null
             } else {
                 projetosLegislativosList.value = [...projetosLegislativosList.value, ...mapped]
             }
 
+            totalProjetosLegislativos.value = data.paginacao?.total || 0
+            projetosLegislativosDistribuicao.value = data.estatisticas?.distribuicao_tipos || []
             projetosLegislativosPage.value = pagina
-            hasMoreProjetosLegislativos.value = mapped.length === 15
+            hasMoreProjetosLegislativos.value = projetosLegislativosList.value.length < totalProjetosLegislativos.value
         } catch (e: any) {
             console.error("Erro ao buscar projetos legislativos:", e)
+            error.value = "Erro ao carregar projetos legislativos."
         } finally {
             loadingProjetosLegislativos.value = false
         }
@@ -433,23 +442,10 @@ export const useSenadoStore = defineStore("senado", () => {
         await fetchVotacaoMateria(id)
     }
 
-    const filteredProjetosLegislativos = computed(() => {
-        return projetosLegislativosList.value.filter((p) => {
-            if (projetosLegislativosFilters.value.search && !p.ementa.toLowerCase().includes(projetosLegislativosFilters.value.search.toLowerCase())) {
-                return false
-            }
-            if (projetosLegislativosFilters.value.siglaTipo && p.siglaTipo !== projetosLegislativosFilters.value.siglaTipo) {
-                return false
-            }
-            if (projetosLegislativosFilters.value.ano && p.ano !== Number(projetosLegislativosFilters.value.ano)) {
-                return false
-            }
-            return true
-        })
-    })
+    const filteredProjetosLegislativos = computed(() => projetosLegislativosList.value)
 
     const tiposUnicosProjetosLegislativos = computed(() => {
-        const tipos = new Set(projetosLegislativosList.value.map((p) => p.siglaTipo))
+        const tipos = new Set(projetosLegislativosDistribuicao.value.map((p) => p.tipo))
         return Array.from(tipos).sort()
     })
 
@@ -458,15 +454,7 @@ export const useSenadoStore = defineStore("senado", () => {
         return Array.from(anos).sort((a, b) => b - a)
     })
 
-    const projetosLegislativosPorTipo = computed(() => {
-        const contagem: Record<string, number> = {}
-        filteredProjetosLegislativos.value.forEach((p) => {
-            contagem[p.siglaTipo] = (contagem[p.siglaTipo] || 0) + 1
-        })
-        return Object.entries(contagem)
-            .map(([tipo, quantidade]) => ({ tipo, quantidade }))
-            .sort((a, b) => b.quantidade - a.quantidade)
-    })
+    const projetosLegislativosPorTipo = computed(() => projetosLegislativosDistribuicao.value)
 
     const setProjetosLegislativosFilter = (key: keyof ProjetosLegislativosFilters, value: string) => {
         projetosLegislativosFilters.value[key] = value
@@ -517,6 +505,7 @@ export const useSenadoStore = defineStore("senado", () => {
         // Projetos Legislativos
         projetosLegislativosFilters,
         projetosLegislativosList,
+        totalProjetosLegislativos,
         loadingProjetosLegislativos,
         filteredProjetosLegislativos,
         tiposUnicosProjetosLegislativos,

--- a/frontend/src/stores/senado.ts
+++ b/frontend/src/stores/senado.ts
@@ -41,6 +41,7 @@ export interface EmendaSenado {
 export interface EstatisticasSenadoGerais {
     total_senadores: number
     total_gastos: number
+    total_regioes: number
     senadores_por_regiao: { name: string; value: number }[]
 }
 


### PR DESCRIPTION
This pull request introduces several improvements and new features to both backend and frontend related to legislative project listings, statistics, and API documentation. The main focus is on enhancing the richness and accuracy of statistical data, improving pagination and filtering for legislative projects, and updating the UI to reflect these backend changes.

**Backend Improvements:**

- **Enhanced API Responses and Filtering:**
  - The `/proposicoes` and `/materia/listar` endpoints now return richer statistical data, including total counts, the most frequent type, and distribution by type. Pagination and filtering logic have been refactored for clarity and extensibility. The `limite` parameter now has validation for minimum and maximum values. [[1]](diffhunk://#diff-e87933497cf5269a5d33c7f2ebbc7b2990daf121f5ac51c0d44404b0a1e410b4L326-R327) [[2]](diffhunk://#diff-e87933497cf5269a5d33c7f2ebbc7b2990daf121f5ac51c0d44404b0a1e410b4L337-R410) [[3]](diffhunk://#diff-e87933497cf5269a5d33c7f2ebbc7b2990daf121f5ac51c0d44404b0a1e410b4R431-R436) [[4]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adR76) [[5]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adL102-R105)
  - The `/estatisticas` endpoint for deputies now includes `total_regioes`, `total_ufs`, and `deputados_por_regiao` in its response, with new queries to support these stats. [[1]](diffhunk://#diff-e87933497cf5269a5d33c7f2ebbc7b2990daf121f5ac51c0d44404b0a1e410b4R598-R615) [[2]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adR56)

- **Other Backend Changes:**
  - The comparison endpoint for deputies now fetches the 12 most recent expenses per deputy, sorted by the actual document date if available, for more accurate historical data.

**Frontend Updates:**

- **Statistics and Project Listings:**
  - The statistics components for both Câmara and Senado now display dynamic values for regions and states (UFs), reflecting the updated backend responses. [[1]](diffhunk://#diff-104088c40af98055da88425195f4b548203e478750fefa431e78c947eb19c534L27-R27) [[2]](diffhunk://#diff-104088c40af98055da88425195f4b548203e478750fefa431e78c947eb19c534L53-R53) [[3]](diffhunk://#diff-104088c40af98055da88425195f4b548203e478750fefa431e78c947eb19c534R160-R169) [[4]](diffhunk://#diff-d381d3095019f7cfd8325a91c9fce8aff344ea01b39d861a4ea9f6a2dc8e8392L27-R27)
  - The legislative project lists for Câmara and Senado now show the total number of projects according to backend pagination/statistics, not just the current filtered list. [[1]](diffhunk://#diff-57b999cd8bccaa6d90df46ebbf53f814330eb8c63a8a7ba2906e643c0dd7b326L5-R5) [[2]](diffhunk://#diff-82aebfc2418830a5681457c942fc3975f86099f61ea09c095eb1956412f2777eL12-R12)
  - The Senado project list now has a "Load more" button for paginated loading.

- **UI/UX Improvements:**
  - The display for comparing deputy expenses now includes an "Empate" (tie) badge if totals are equal and improves the summary message for the difference. [[1]](diffhunk://#diff-c291e5c3728df1e4755c690e2cce3861d0c49f74bf8c2f3720637392ac2df41aL258-R259) [[2]](diffhunk://#diff-c291e5c3728df1e4755c690e2cce3861d0c49f74bf8c2f3720637392ac2df41aL268-R270) [[3]](diffhunk://#diff-c291e5c3728df1e4755c690e2cce3861d0c49f74bf8c2f3720637392ac2df41aL281-R283)
  - The calculation for legislative periods in the select component is clarified to correctly represent the 4-year span.
  - The Senado statistics chart sorts the last 5 months by date for more accurate recent trends.
  - The Câmara project list now always displays all fetched projects, removing the previous slice-based limitation. [[1]](diffhunk://#diff-0af4b2f956ef8ace4aeb920557c4051114d0c217f659f6c845530769627e72e1L18-R18) [[2]](diffhunk://#diff-0af4b2f956ef8ace4aeb920557c4051114d0c217f659f6c845530769627e72e1L209-R215)

**API Documentation:**

- The API documentation (`README_API.md`) is updated to reflect the new response structures and parameters for the affected endpoints. [[1]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adR56) [[2]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adR76) [[3]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adL102-R105)

---

### Backend: API and Data Enhancements

- `/proposicoes` and `/materia/listar` endpoints now return richer statistics (total, most frequent type, type distribution) and support for `limite` parameter with validation. [[1]](diffhunk://#diff-e87933497cf5269a5d33c7f2ebbc7b2990daf121f5ac51c0d44404b0a1e410b4L326-R327) [[2]](diffhunk://#diff-e87933497cf5269a5d33c7f2ebbc7b2990daf121f5ac51c0d44404b0a1e410b4L337-R410) [[3]](diffhunk://#diff-e87933497cf5269a5d33c7f2ebbc7b2990daf121f5ac51c0d44404b0a1e410b4R431-R436) [[4]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adR76) [[5]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adL102-R105)
- `/estatisticas` endpoint now includes `total_regioes`, `total_ufs`, and `deputados_por_regiao` with supporting queries. [[1]](diffhunk://#diff-e87933497cf5269a5d33c7f2ebbc7b2990daf121f5ac51c0d44404b0a1e410b4R598-R615) [[2]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adR56)

### Backend: Other Improvements

- Deputies' comparison endpoint now returns the 12 most recent expenses per deputy, sorted by document date for accuracy.

### Frontend: Statistics and Project Listings

- Statistics components now display dynamic regions and UFs based on backend data. [[1]](diffhunk://#diff-104088c40af98055da88425195f4b548203e478750fefa431e78c947eb19c534L27-R27) [[2]](diffhunk://#diff-104088c40af98055da88425195f4b548203e478750fefa431e78c947eb19c534L53-R53) [[3]](diffhunk://#diff-104088c40af98055da88425195f4b548203e478750fefa431e78c947eb19c534R160-R169) [[4]](diffhunk://#diff-d381d3095019f7cfd8325a91c9fce8aff344ea01b39d861a4ea9f6a2dc8e8392L27-R27)
- Legislative project lists show backend total counts and support paginated loading for Senado. [[1]](diffhunk://#diff-57b999cd8bccaa6d90df46ebbf53f814330eb8c63a8a7ba2906e643c0dd7b326L5-R5) [[2]](diffhunk://#diff-82aebfc2418830a5681457c942fc3975f86099f61ea09c095eb1956412f2777eL12-R12) [[3]](diffhunk://#diff-57b999cd8bccaa6d90df46ebbf53f814330eb8c63a8a7ba2906e643c0dd7b326R191-R201)

### Frontend: UI/UX Improvements

- Comparison page now handles ties and improves difference summaries. [[1]](diffhunk://#diff-c291e5c3728df1e4755c690e2cce3861d0c49f74bf8c2f3720637392ac2df41aL258-R259) [[2]](diffhunk://#diff-c291e5c3728df1e4755c690e2cce3861d0c49f74bf8c2f3720637392ac2df41aL268-R270) [[3]](diffhunk://#diff-c291e5c3728df1e4755c690e2cce3861d0c49f74bf8c2f3720637392ac2df41aL281-R283)
- Legislative period calculation in select component clarified.
- Senado statistics chart sorts months by date for accuracy.
- Câmara project list shows all fetched projects, removing slicing. [[1]](diffhunk://#diff-0af4b2f956ef8ace4aeb920557c4051114d0c217f659f6c845530769627e72e1L18-R18) [[2]](diffhunk://#diff-0af4b2f956ef8ace4aeb920557c4051114d0c217f659f6c845530769627e72e1L209-R215)

### API Documentation

- Updated `README_API.md` to document new response fields and parameters for endpoints. [[1]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adR56) [[2]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adR76) [[3]](diffhunk://#diff-a6dbba3a61089bf1f3bbbf8791fecce989f3d6968e340f8cadd1df36f68062adL102-R105)